### PR TITLE
Port #391, fix PAPAG versions, a few other tweaks

### DIFF
--- a/agentos/cli.py
+++ b/agentos/cli.py
@@ -164,8 +164,10 @@ def run(
         arg_set = ArgumentSet()
     args = literal_eval(arg_set_args.lstrip()) if arg_set_args else None
     kwargs = literal_eval(arg_set_kwargs.lstrip()) if arg_set_kwargs else None
-    arg_set.args.append(args)
-    arg_set.kwargs.update(kwargs)
+    if args is not None:
+        arg_set.args.append(args)
+    if kwargs is not None:
+        arg_set.kwargs.update(kwargs)
 
     output = comp.run_with_arg_set(function_name, arg_set)
     print(f"Output {output.identifier} recorded.", end=" ")

--- a/example_agents/acme_dqn/requirements.txt
+++ b/example_agents/acme_dqn/requirements.txt
@@ -66,7 +66,7 @@ Markdown==3.3.4
 MarkupSafe==2.0.1
 matplotlib>=3.3.4
 mccabe==0.6.1
-mlflow==1.23.1
+mlflow==1.26.1
 msrest==0.6.21
 mypy-extensions==0.4.3
 numpy==1.21.0
@@ -81,7 +81,7 @@ pygame==2.1.2
 progress==1.5
 prometheus-client==0.11.0
 prometheus-flask-exporter==0.18.2
-protobuf==3.17.3
+protobuf==3.20.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20

--- a/example_agents/acme_r2d2/requirements.txt
+++ b/example_agents/acme_r2d2/requirements.txt
@@ -66,7 +66,7 @@ Markdown==3.3.4
 MarkupSafe==2.0.1
 matplotlib>=3.3.4
 mccabe==0.6.1
-mlflow==1.23.1
+mlflow==1.26.1
 msrest==0.6.21
 mypy-extensions==0.4.3
 numpy==1.21.0
@@ -81,7 +81,7 @@ pygame==2.1.2
 progress==1.5
 prometheus-client==0.11.0
 prometheus-flask-exporter==0.18.2
-protobuf==3.17.3
+protobuf==3.20.1
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.20

--- a/example_agents/papag/README.md
+++ b/example_agents/papag/README.md
@@ -7,13 +7,13 @@
 AgentOS Train:
 
 ```
-agentos run agent --function-name learn --arg-set-file a2c_pong_args.yaml
+agentos run papag_agent --registry-file components.yaml --registry-file a2c_cartpole_args.yaml --arg-set-id a2c_cartpole_args --function-name learn
 ```
 
 AgentOS Evaluate:
 
 ```
-agentos run agent --function-name evaluate --arg-set-file a2c_pong_args.yaml
+agentos run papag_agent --registry-file components.yaml --registry-file a2c_cartpole_args.yaml --arg-set-id a2c_cartpole_args --function-name learn
 ```
 
 Equivalent to [this command](https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail#a2c).
@@ -23,13 +23,13 @@ Equivalent to [this command](https://github.com/ikostrikov/pytorch-a2c-ppo-acktr
 train:
 
 ```
-agentos run agent --function-name learn --arg-set-file ppo_pong_args.yaml
+TODO: once spec v2 is finished
 ```
 
 evaluate:
 
 ```
-agentos run agent --function-name evaluate --arg-set-file ppo_pong_args.yaml
+TODO: once spec v2 is finished
 ```
 
 Equivalent to [this command](https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail#ppo).
@@ -40,14 +40,13 @@ Equivalent to [this command](https://github.com/ikostrikov/pytorch-a2c-ppo-acktr
 train:
 
 ```
-agentos run agent --function-name learn --arg-set-file acktr_pong_args.yaml
+TODO: once spec v2 is finished
 ```
 
 evaluate:
 
 ```
-agentos run agent --function-name evaluate --arg-set-file acktr_pong_args.yaml
+TODO: once spec v2 is finished
 ```
 
 Equivalent to [this command](https://github.com/ikostrikov/pytorch-a2c-ppo-acktr-gail#acktr).
-

--- a/example_agents/papag/components.yaml
+++ b/example_agents/papag/components.yaml
@@ -29,10 +29,10 @@ specs:
             type: ArgumentSet
             kwargs:
                 PAPAGRun: spec:PAPAGRun
-                AtariEnv: spec:AtariEnv==db3728264f382402120913d76c4fa0dc320ef59f
-                CartPoleEnv: spec:CartPoleEnv==4ede9280f9c477f1ca09929d10cdc1e1ba1129f1
-                A2C_ACKTR: spec:A2C_ACKTR==41332b78dfb50321c29bade65f9d244387f68a60
-                PPO: spec:PPO==41332b78dfb50321c29bade65f9d244387f68a60
+                AtariEnv: spec:AtariEnv
+                CartPoleEnv: spec:CartPoleEnv
+                A2C_ACKTR: spec:A2C_ACKTR
+                PPO: spec:PPO
 
     PAPAGRun:
         type: Class
@@ -42,34 +42,38 @@ specs:
             repo: spec:papag_agent_dir
             file_path: papag_run.py
 
-    AtariEnv==db3728264f382402120913d76c4fa0dc320ef59f:
+    AtariEnv:
         type: Class
         name: AtariEnv
         module:
             type: Module
+            version: db3728264f382402120913d76c4fa0dc320ef59f
             repo: spec:mgbellemare_ale
             file_path: ./src/gym/envs/atari/environment.py
 
-    CartPoleEnv==4ede9280f9c477f1ca09929d10cdc1e1ba1129f1:
+    CartPoleEnv:
         type: Class
         name: CartPoleEnv
         module:
             type: Module
+            version: c755d5c35a25ab118746e2ba885894ff66fb8c43
             repo: spec:openai_gym
             file_path: ./gym/envs/classic_control/cartpole.py
 
-    A2C_ACKTR==41332b78dfb50321c29bade65f9d244387f68a60:
+    A2C_ACKTR:
         type: Class
         name: A2C_ACKTR
         module:
             type: Module
+            version: 41332b78dfb50321c29bade65f9d244387f68a60
             repo: spec:ikostrikov_papag
             file_path: ./a2c_ppo_acktr/algo/a2c_acktr.py
 
-    PPO==41332b78dfb50321c29bade65f9d244387f68a60:
+    PPO:
         type: Class
         name: PPO
         module:
             type: Module
+            version: 41332b78dfb50321c29bade65f9d244387f68a60
             repo: spec:ikostrikov_papag
             file_path: ./a2c_ppo_acktr/algo/ppo.py

--- a/example_agents/sb3_agent/components.yaml
+++ b/example_agents/sb3_agent/components.yaml
@@ -47,7 +47,7 @@ specs:
         name: CartPoleEnv
         module:
             type: Module
-            version: 4ede9280f9c477f1ca09929d10cdc1e1ba1129f1
+            version: c755d5c35a25ab118746e2ba885894ff66fb8c43
             repo: spec:openai_gym
             file_path: ./gym/envs/classic_control/cartpole.py
 

--- a/example_agents/sb3_agent/requirements.txt
+++ b/example_agents/sb3_agent/requirements.txt
@@ -7,7 +7,7 @@ gym[accept-rom-license]==0.21.0
 pygame==2.1.2
 stable-baselines3==1.5.0
 dm-env==1.5
-mlflow==1.25.1
+mlflow==1.26.1
 torch==1.11.0+cpu; sys_platform == 'linux'
 torch==1.11.0; sys_platform == 'win32'
 torch==1.11.0; sys_platform == 'darwin'

--- a/pcs/utils.py
+++ b/pcs/utils.py
@@ -41,7 +41,8 @@ def is_identifier_ref(token: Any) -> bool:
 
 def extract_identifier(identifier_ref: str) -> str:
     assert identifier_ref.startswith(IDENTIFIER_REF_PREFIX)
-    return identifier_ref[len(IDENTIFIER_REF_PREFIX) :]
+    prefix_len = len(IDENTIFIER_REF_PREFIX)
+    return identifier_ref[prefix_len:]
 
 
 def make_identifier_ref(identifier: str) -> str:
@@ -180,7 +181,7 @@ def _handle_random_agent(version_string):
 def _handle_sb3_agent(version_string):
     sb3_path_prefix = Path("example_agents") / Path("sb3_agent")
     atari_env = "AtariEnv==db3728264f382402120913d76c4fa0dc320ef59f"
-    cartpole_env = "CartPoleEnv==4ede9280f9c477f1ca09929d10cdc1e1ba1129f1"
+    cartpole_env = "CartPoleEnv==c755d5c35a25ab118746e2ba885894ff66fb8c43"
     ppo_algo = "PPO==21f6a474a4755996709efee8c0aab309df905cbf"
     sb3_rename_map = {
         "sb3_agent": f"sb3_ppo_agent=={version_string}",

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ setup(
     install_requires=[
         "click>=7.0",
         "pyyaml>=5.4.1",
-        "mlflow>=1.20.2",
+        "mlflow>=1.26.1",
         "dulwich==0.20.28",
         "requests>=2.21.0",
         "python-dotenv>=0.19.1",
+        "protobuf==3.20.1",
         "rich>=10.15.2",
         "deepdiff>=5.8.0",
         "dill>=0.3.4",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "requests>=2.21.0",
         "python-dotenv>=0.19.1",
         "protobuf==3.20.1",
+        "regex==2021.8.28",
         "rich>=10.15.2",
         "deepdiff>=5.8.0",
         "dill>=0.3.4",


### PR DESCRIPTION
This PR:

* Ports https://github.com/agentos-project/agentos/pull/391 to your dev branch
* Adds the versions to the module specs for PAPAG
* Fixes in issue with arg/kwarg handling in the CLI (a.k.a. handle no arg or kwarg gracefully)
* Adds `regex` to the setup.py requirements

Note the PAPAG still doesn't run, but the error now looks much less daunting.  The following commands:

```bash
cd example_agents/papag
agentos clear-cache -y 
rm -rf mlruns/
agentos run papag_agent -K "{'num_env_steps':1, 'num_processes':1}" --registry-file components.yaml --registry-file a2c_cartpole_args.yaml --arg-set-id a2c_cartpole_args --function-name evaluate
```

Result in the following output:

```bash
...
Checking out 6c8abeff152cb129ec4cec105ccbd98e2f57d060
Enumerating objects: 11326, done.
Counting objects: 100% (1178/1178), done.
GitManager: cloning /home/nickj/.agentos/cache/repos_cache/_default/mgbellemare/Arcade-Learning-Environment to /home/nickj/.agentos/cache/repos_cache/mgbellemare/Arcade-Learning-Environment/db3728264f382402120913d76c4fa0dc320ef59f
Compressing objects: 100% (386/386), done.
Total 11326 (delta 815), reused 1080 (delta 768), pack-reused 10148
Checking out 8f3bc3be098f4cac6c4e144f88fd909e1dab4af5
VirtualEnv: no requirement paths; Running in an empty env!
VirtualEnv: Running in Python venv at /home/nickj/.agentos/cache/requirements_cache/python3.9/2e1cfa82b035c26cbbbdae632cea070514eb8b773f616aaeaf668e2f0be8f10d
Checking out 8f3bc3be098f4cac6c4e144f88fd909e1dab4af5
Traceback (most recent call last):
  File "/home/nickj/agentos/lean-env/bin/agentos", line 33, in <module>
    sys.exit(load_entry_point('agentos', 'console_scripts', 'agentos')())
  File "/home/nickj/agentos/lean-env/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/nickj/agentos/lean-env/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/nickj/agentos/lean-env/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/nickj/agentos/lean-env/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/nickj/agentos/lean-env/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/nickj/agentos/agentos/cli.py", line 172, in run
    output = comp.run_with_arg_set(function_name, arg_set)
  File "/home/nickj/agentos/pcs/object_manager.py", line 101, in run_with_arg_set
    obj = self.get_object()
  File "/home/nickj/agentos/pcs/instance_manager.py", line 37, in get_object
    self._instance = cls(
TypeError: __init__() got an unexpected keyword argument 'PPO'

```

Note this is the same as #1, I just wanted it on a different branch in my fork.